### PR TITLE
Do not use reserved identifiers

### DIFF
--- a/model.h
+++ b/model.h
@@ -1,5 +1,5 @@
-#ifndef __AIRPORT_H__
-#define __AIRPORT_H__
+#ifndef AIRPORT_H_
+#define AIRPORT_H_
 
 #include <ross.h>
 


### PR DESCRIPTION
Identifiers containing a double underscore or beginning with an
underscore followed by a capital letter are reserved by the standard.
